### PR TITLE
Add constant beginTime to keyFrameAnimationForCurrentPreferences

### DIFF
--- a/ITProgressIndicator/Classes/ITProgressIndicator.m
+++ b/ITProgressIndicator/Classes/ITProgressIndicator.m
@@ -234,7 +234,8 @@
     [animation setKeyTimes:keyTimeValues];
     [animation setValueFunction:[CAValueFunction functionWithName: kCAValueFunctionRotateZ]];
     [animation setDuration:self.animationDuration];
-    
+    [animation setBeginTime: 1];
+      
     return animation;
 }
 


### PR DESCRIPTION
This ensures that all instances of ITProgressIndicator within an application are animated in sync with one another, regardless of whether their animations were started at the same time/within the same animation group. This mimics the behaviour of NSProgressIndicator when embedded in a layer-backed view.

**Before:**

![before](https://cloud.githubusercontent.com/assets/6810144/25468486/7f0eb70c-2b59-11e7-84d3-ef0828698d11.gif)

**After:**

![after](https://cloud.githubusercontent.com/assets/6810144/25468495/8ac7d632-2b59-11e7-8576-d853c87c3dbb.gif)